### PR TITLE
add support for natural-compare-lite returning function

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,8 +9,12 @@ function gulpNaturalSort(order) {
   }
 
   function onEnd() {
-    require('natural-compare-lite');
+    var ncl = require('natural-compare-lite');
     var _this = this;
+
+    if (ncl !== undefined) {
+      String.naturalCompare = ncl;
+    }
 
     files.sort(function(a, b) {
       return String.naturalCompare(a.relative.toLowerCase(), b.relative.toLowerCase());

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-natural-sort",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Sort stream by path name using a natural sort",
   "main": "index.js",
   "keywords": [


### PR DESCRIPTION
While testing gulp usage of gulp-natural-sort today (10/26/2015) started getting undefined for String.naturalCompare usage.  This fix adds a condition to see if natural-compare-lite returns a function instead of modifying the global String object.
